### PR TITLE
Suggestion to change units to minutes

### DIFF
--- a/custom_components/state_updated/__init__.py
+++ b/custom_components/state_updated/__init__.py
@@ -46,7 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: CommonConfigEntry) -> bo
         hass,
         LOGGER,
         name=DOMAIN,
-        update_interval=timedelta(minutes=1),
+        update_interval=timedelta(seconds=30),
         update_method=component_api.async_update,
     )
 

--- a/custom_components/state_updated/component_api.py
+++ b/custom_components/state_updated/component_api.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.template import Template
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
-    CONF_CLEAR_UPDATES_AFTER_HOURS,
+    CONF_CLEAR_UPDATES_AFTER_MINUTES,
     CONF_LAST_UPDATED,
     CONF_NEW_VALUE,
     CONF_OLD_VALUE,
@@ -115,7 +115,7 @@ class ComponentApi:
 
         if self.updated and (
             self.last_updated
-            + timedelta(hours=self.entry.options[CONF_CLEAR_UPDATES_AFTER_HOURS])
+            + timedelta(minutes=self.entry.options[CONF_CLEAR_UPDATES_AFTER_MINUTES])
         ) < datetime.now(UTC):
             self.updated = False
             self.text = ""

--- a/custom_components/state_updated/config_flow.py
+++ b/custom_components/state_updated/config_flow.py
@@ -33,7 +33,7 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import (
-    CONF_CLEAR_UPDATES_AFTER_HOURS,
+    CONF_CLEAR_UPDATES_AFTER_MINUTES,
     CONF_DEFAULT_TEXT_TEMPLATE,
     CONF_LAST_UPDATED,
     CONF_NEW_VALUE,
@@ -92,13 +92,13 @@ async def init_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
                 CONF_ICON,
             ): IconSelector(),
             vol.Optional(CONF_DEVICE_ID, default=dev_id): selector.DeviceSelector(),
-            vol.Required(CONF_CLEAR_UPDATES_AFTER_HOURS, default=25): NumberSelector(
+            vol.Required(CONF_CLEAR_UPDATES_AFTER_MINUTES, default=10): NumberSelector(
                 NumberSelectorConfig(
-                    min=0.1,
-                    max=999,
+                    min=0.017,
+                    max=43200,
                     step="any",
                     mode=NumberSelectorMode.BOX,
-                    unit_of_measurement="hours",
+                    unit_of_measurement="minutes",
                 )
             ),
             vol.Optional(

--- a/custom_components/state_updated/const.py
+++ b/custom_components/state_updated/const.py
@@ -6,7 +6,7 @@ DOMAIN = "state_updated"
 DOMAIN_NAME = "State updated"
 LOGGER: Logger = getLogger(__name__)
 
-CONF_CLEAR_UPDATES_AFTER_HOURS = "clear_update_after_hours"
+CONF_CLEAR_UPDATES_AFTER_MINUTES = "clear_update_after_minutes"
 CONF_NEW_VALUE = "new_value"
 CONF_OLD_VALUE = "old_value"
 CONF_LAST_UPDATED = "last_updated"

--- a/custom_components/state_updated/strings.json
+++ b/custom_components/state_updated/strings.json
@@ -58,7 +58,7 @@
         "data": {
           "attribute": "Attribute of entity that this sensor tracks",
           "icon": "Icon",
-          "clear_update_after_hours": "Clear updates after",
+          "clear_update_after_minutes": "Clear updates after",
           "text_template": "Defines a template to create the text attribute. Value = new_value, old_value, entity_id, attribute and last_updated",
           "default_text_template": "Entity {{ entity_id }} state changed from {{ old_value }} from {{ new_value }}."
         }


### PR DESCRIPTION
Personally, I would find this plugin more useful if it were a bit more reactive to state changes. I will admit that this could have been a one line change - one decimal place, to be exact - but using minutes is more intuitive. At the very least, I would like to be able to track the state of my locks as binary sensors with 30 second granularity. 